### PR TITLE
extended getTitle functionality to courseWork as well

### DIFF
--- a/course_util.js
+++ b/course_util.js
@@ -1,10 +1,10 @@
-function getCourseList(courseData) {
+function getCourseList(courseData, prop) {
     var titles = {}
     for (var i = 0; i <= courseData.length; i++) {
-        if (typeof courseData[i] === 'object' && courseData[i]['courseWork']) {
-            for (var j = 0; j <= courseData[i]['courseWork'].length; j++) {
-                if (courseData[i]['courseWork'][j]) {
-                    titles[courseData[i]['courseWork'][j].id] = courseData[i]['courseWork'][j].title
+        if (typeof courseData[i] === 'object' && courseData[i][prop]) {
+            for (var j = 0; j <= courseData[i][prop].length; j++) {
+                if (courseData[i][prop][j]) {
+                    titles[courseData[i][prop][j].id] = courseData[i][prop][j].title || courseData[i][prop][j].name
                 }
             }
         }

--- a/course_util.py
+++ b/course_util.py
@@ -118,7 +118,11 @@ def log_all(results):
 
 def courselist(resp):
     #get list of courses mapped to ids
-    return course_utiljs.getCourseList(resp)
+    return course_utiljs.getCourseList(resp, "courses")
+
+def courseWorklist(resp):
+    #get list of courses mapped to ids
+    return course_utiljs.getCourseList(resp, "courseWork")
 
 def roster(course):
     #get list of students&teachers mapped to ids


### PR DESCRIPTION
PR is aimed to extend functionality for the data manager to pull a list of courseWork ID's mapped to courseWork titles as well as course titles to course ID's.

code was tested on iterm:
<img width="1280" alt="Screen Shot 2020-08-19 at 2 40 52 PM" src="https://user-images.githubusercontent.com/26152604/90692733-781ea700-e22a-11ea-8883-20618967d878.png">
