### PR TITLE
Fix bug - double string conversion

### DIFF
--- a/course_util.py
+++ b/course_util.py
@@ -212,7 +212,7 @@ ref_d = json.loads(ref_f)
 
 def pullcustom():
     batch_s.execute()
-    return(str(sub_list))
+    return sub_list
 
 
 string = json.dumps(pullcustom(), sort_keys=True, indent=4)


### PR DESCRIPTION
Fix a bug that was resulting in an empty submissions.json file. By converting `sub_list` to a string and then calling `json.dumps` with that string, we ended up with extra quotation marks around the resulting list. This didn't seem to work well with the `pare` function in `to_csv.py`.

This was preventing the script from working entirely for me, so if it was working for you it's probably worth patching this one first to make sure it doesn't break anything before merging.